### PR TITLE
Use six to make library compatible with Python 2 and 3

### DIFF
--- a/authliboclc/authcode.py
+++ b/authliboclc/authcode.py
@@ -16,16 +16,16 @@
 # limitations under the License.
 ###############################################################################
 
-"""Class represents and authentication code object
+"""
+Class represents and authentication code object
 
 HMAC Requests, which are strictly server side, use an Authenication Code object to store their parameters
 and perform hashing.
-
 """
 
-from urlparse import urlparse
-import urllib
 import string
+
+import six
 
 
 class InvalidParameter(Exception):
@@ -84,36 +84,35 @@ class AuthCode(object):
         self.redirect_uri = redirect_uri
         self.scopes = scopes
 
-        if self.client_id == None:
+        if self.client_id is None:
             raise InvalidParameter('Required option missing: client_id.')
         elif self.client_id == '':
             raise InvalidParameter('Cannot be empty string: client_id.')
 
-        if self.authenticating_institution_id == None:
+        if self.authenticating_institution_id is None:
             raise InvalidParameter('Required option missing: authenticating_institution_id.')
         elif self.authenticating_institution_id == '':
             raise InvalidParameter('Cannot be empty string: authenticating_institution_id.')
 
-        if self.context_institution_id == None:
+        if self.context_institution_id is None:
             raise InvalidParameter('Required option missing: context_institution_id.')
         elif self.context_institution_id == '':
             raise InvalidParameter('Cannot be empty string: context_institution_id.')
 
-        if self.redirect_uri == None:
+        if self.redirect_uri is None:
             raise InvalidParameter('Required option missing: redirect_uri.')
         elif self.redirect_uri == '':
             raise InvalidParameter('Cannot be empty string: redirect_uri.')
         else:
-            scheme = urlparse("".join(self.redirect_uri)).scheme
-            if scheme != 'http' and scheme != 'https':
+            scheme = six.moves.urllib.parse.urlparse("".join(self.redirect_uri)).scheme
+            if not scheme == 'http' and not scheme == 'https':
                 raise InvalidParameter('Invalid redirect_uri. Must begin with http:// or https://')
 
-        if self.scopes == None or self.scopes == '':
+        if self.scopes is None or self.scopes == '':
             raise InvalidParameter(
                 'Required option missing: scopes. Note scopes must be a list of one or more scopes.')
-        elif len(self.scopes) == 0 or self.scopes[0] == None or self.scopes[0] == '':
+        elif not self.scopes or not self.scopes[0]:
             raise InvalidParameter('You must pass at least one valid scope')
-
 
     def get_login_url(self):
         """Returns a login url based on the auth code parameters."""
@@ -122,7 +121,7 @@ class AuthCode(object):
             '?' + 'authenticatingInstitutionId=' + self.authenticating_institution_id +
             '&' + 'client_id=' + self.client_id +
             '&' + 'contextInstitutionId=' + self.context_institution_id +
-            '&' + urllib.urlencode({'redirect_uri': self.redirect_uri}) +
+            '&' + six.moves.urllib.parse.urlencode({'redirect_uri': self.redirect_uri}) +
             '&' + 'response_type=code' +
             '&' + 'scope=' + " ".join(self.scopes)
         )

--- a/authliboclc/refreshtoken.py
+++ b/authliboclc/refreshtoken.py
@@ -25,7 +25,6 @@
 """
 
 import time
-from time import mktime
 import string
 
 
@@ -56,10 +55,10 @@ class RefreshToken(object):
             expires_at: string, the ISO 8601 time that the refresh token expires at
             expires_in: int, the number of seconds until the token expires
         """
-        if tokenValue == None or expires_in == None or expires_at == None:
+        if tokenValue is None or expires_in is None or expires_at is None:
             raise InvalidParameter('You must pass these parameters: tokenValue, expires_in and expires_at')
 
-        if type(expires_in) is not int:
+        if not isinstance(expires_in, int):
             raise InvalidParameter('expires_in must be an int')
 
         self.refresh_token = tokenValue
@@ -73,7 +72,7 @@ class RefreshToken(object):
             isExpired: boolean, true if refresh token is expired
         """
         status = False
-        if mktime(time.strptime(self.expires_at, "%Y-%m-%d %H:%M:%SZ")) < time.time():
+        if time.mktime(time.strptime(self.expires_at, "%Y-%m-%d %H:%M:%SZ")) < time.time():
             status = True
         return status
 

--- a/authliboclc/user.py
+++ b/authliboclc/user.py
@@ -54,11 +54,11 @@ class User(object):
             principal_id: string, the principal identifier
             principal_idns: string, the principal identifier namespace
         """
-        if authenticating_institution_id == None or authenticating_institution_id == '':
+        if not authenticating_institution_id:
             raise InvalidParameter('You must set a valid Authenticating Institution ID')
-        if principal_id == None or principal_id == '':
+        if not principal_id:
             raise InvalidParameter('You must set a valid principal_id')
-        if principal_idns == None or principal_idns == '':
+        if not principal_idns:
             raise InvalidParameter('You must set a valid principal_idns')
 
         self.authenticating_institution_id = authenticating_institution_id

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+import setuptools
 
 setup(
     name = 'authliboclc',

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ setup(
     author_email = "devnet@oclc.org",
     url = 'http://oclc.org/developer/home.en.html',
     download_url = 'git@github.com:OCLC-Developer-Network/oclc-auth-python.git',
+    install_requires = ['six>=1']
 )

--- a/tests/wskey_test.py
+++ b/tests/wskey_test.py
@@ -176,7 +176,7 @@ class WskeyTests(unittest.TestCase):
                     'userid="tasty"'
         )
 
-        self.assertEquals(AuthenticationHeader, expected)
+        self.assertEqual(AuthenticationHeader, expected)
 
     """ Verify the correctness of the hashing algorithm. """
 


### PR DESCRIPTION
Added compatibility library 'six' under 'install_requires'  of setup.py, will download as a dependency when installing library.

Six allows for making the code work under Python 2 and 3 runtimes, and is a single file, so dependency does not add much weight.

Only refactoring, no new functionality added, so no new tests, but all tests pass under 2 and 3. Only change to a test was changing a single deprecated 'assertEquals' to 'assertEqual'.

Also tested an actual request with 2.7 and 3.4, both worked as expected.
